### PR TITLE
Update Makefile.PL - consistency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,31 +5,31 @@ use ExtUtils::MakeMaker;
 my $required_mech_version
  =	eval {
 	   require LWP::UserAgent and
-	      LWP'UserAgent->VERSION < 5.815 && LWP'UserAgent->VERSION >= 5
-	   and require HTTP::Message and HTTP'Message->VERSION >= 1.34
-	   and require HTTP::Request and HTTP'Request->VERSION >= 1.29
-	   and require HTTP'Response and HTTP'Response->VERSION >= 1.35
+	      LWP::UserAgent->VERSION < 5.815 && LWP::UserAgent->VERSION >= 5
+	   and require HTTP::Message and HTTP::Message->VERSION >= 1.34
+	   and require HTTP::Request and HTTP::Request->VERSION >= 1.29
+	   and require HTTP::Response and HTTP::Response->VERSION >= 1.35
 	}
 	   ? 1.2 # cookie cloning
 	   : 1.52 # compatibility with LWP 5.815 with regard to credentials
 ;
 
 my %prereq = (                          
-	CSS'DOM'Interface          => 0,
+	CSS::DOM::Interface          => 0,
 	Encode                     => 0,
 	Exporter                   => 5.57,
 	HTML::DOM                  =>  .045, # weaken_response
-	HTML'DOM'Collection        => 0,
-	HTML'DOM'EventTarget       =>  .053, # DOMAttrModified events with
+	HTML::DOM::Collection        => 0,
+	HTML::DOM::EventTarget       =>  .053, # DOMAttrModified events with
 	                                            # correct type and can-
 	HTML::DOM::Interface       =>  .019, # EventTarget  # cellability
 	HTML::DOM::NodeList::Magic =>  .020, # 2nd arg to new            
-	HTML'DOM'View              =>  .018, # inside-out; writa-
+	HTML::DOM::View              =>  .018, # inside-out; writa-
 	HTTP::Headers::Util        => 0,     # ble document
 	HTTP::Message              => 1.34, # array ref headers
 	HTTP::Request              => 1.29, # URI instead of URI::URL
-	HTTP'Response              => 1.35, # likewise
-	List'Util                  => 0,
+	HTTP::Response              => 1.35, # likewise
+	List::Util                  => 0,
 	LWP                        => 5,
 	LWP::Protocol              => 0, # version 1.22 at the earliest
 	                                      # (LWP 5), for the collect
@@ -37,9 +37,9 @@ my %prereq = (
 	Scalar::Util               => 1.09, # reftype  # sion  didn’t  in-
 	strict                     => 0,                  # clude $VERSION
 	eval { require Hash::Util::FieldHash } ? () : (
-	 Tie'RefHash'Weak          => 0.08, # fieldhash
+	 Tie::RefHash::Weak          => 0.08, # fieldhash
 	),
-	Time'HiRes                 => 0,
+	Time::HiRes                 => 0,
 	URI                        => 0,
 	warnings                   => 0,
 	WWW::Mechanize           => $required_mech_version,
@@ -47,9 +47,9 @@ my %prereq = (
 	WWW::Mechanize::Link     => 0,
 # for testing:
 #	HTML'DOM      =>  .03, # doc->title when title elem is empty
-	HTML'DOM'Element'Form => .039, # make_request with GET and data:
+	HTML::DOM::Element::Form => .039, # make_request with GET and data:
 	lib           => 0,
-	Scalar'Util   => 1.09, # refaddr
+	Scalar::Util   => 1.09, # refaddr
 	Test::More    => 0,
 	URI::data     => 0,
 	URI::file     => 0,


### PR DESCRIPTION
Hi,

thanks for your work on this module.
This short PR changes occurances of ' to :: for consistency.
e.g.

`and require HTTP::Message and HTTP'Message->VERSION >= 1.34`

becomes

`and require HTTP::Message and HTTP::Message->VERSION >= 1.34`
